### PR TITLE
Enable a11y check for about page

### DIFF
--- a/test/integration/a11y.spec.ts
+++ b/test/integration/a11y.spec.ts
@@ -18,7 +18,7 @@ test.describe('Homepage', () => {
   });
 });
 
-test.describe.skip('about page', () => {
+test.describe('about page', () => {
   test('should not have any automatically detectable accessibility issues', async ({
     page,
   }, testInfo) => {


### PR DESCRIPTION
Now that #7 is merged we can enable the a11y checks for the page. Let's see what the result is!

The results can be found on the github action page here: https://github.com/NASA-IMPACT/next-earth-gov/actions/runs/14519634294/job/40737124620?pr=9

But they are also uploaded as Artifact, Artifact download URL: https://github.com/NASA-IMPACT/next-earth-gov/actions/runs/14519634294/artifacts/2964930108

It requires a bit of practice to read the report, but it comes down to only two issues, `color-contrast` (on several elements) and `page-has-heading-one` (page currently has no `<h1 />`).