### PR TITLE
Add skipnav button

### DIFF
--- a/app/components/header/__snapshots__/header.test.tsx.snap
+++ b/app/components/header/__snapshots__/header.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`Header Component > matches the snapshot (no unintended side-effects) 1`
         type="button"
       >
         <svg
+          aria-label="Open menu"
           class="usa-icon usa-icon--size-3"
           focusable="false"
           height="1em"

--- a/app/components/header/index.tsx
+++ b/app/components/header/index.tsx
@@ -123,7 +123,7 @@ export default function Header() {
             </Title>
             <NavMenuButton
               onClick={onMenuClick}
-              label={<Icon.Menu size={3} />}
+              label={<Icon.Menu size={3} aria-label='Open menu' />}
             />
           </div>
           <PrimaryNav

--- a/app/components/header/index.tsx
+++ b/app/components/header/index.tsx
@@ -92,8 +92,24 @@ export default function Header() {
     </>,
   ];
 
+  const skipNav = (e) => {
+    e.preventDefault();
+    const mainElement = document.querySelector('main');
+    if (mainElement) {
+      mainElement.setAttribute('tabindex', '-1');
+      mainElement.focus();
+    }
+  };
+
   return (
     <div ref={headerRef}>
+      <button
+        type='button'
+        className='usa-skipnav z-200 margin-2'
+        onClick={skipNav}
+      >
+        Skip to main content
+      </button>
       <USWDSHeader basic={true} showMobileOverlay={isMobileExpanded}>
         <div className='usa-nav-container desktop:padding-y-2'>
           <div

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,9 +45,7 @@ export default function RootLayout({
       <body>
         <div className='minh-viewport display-flex flex-column'>
           <Header />
-          <main id='pagebody' tabIndex={-1} className='flex-fill'>
-            {children}
-          </main>
+          <main className='flex-fill outline-0'>{children}</main>
           <Footer />
         </div>
       </body>

--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -21,12 +21,6 @@ body {
   grid-column: 1 / -1;
 }
 
-#pagebody {
-  &:focus {
-    outline: 0;
-  }
-}
-
 .link--block {
   position: absolute;
   top: 0;

--- a/app/themes/ThemeHero.tsx
+++ b/app/themes/ThemeHero.tsx
@@ -28,7 +28,11 @@ export default function ThemeHero({
             href='/'
             className='usa-link text-primary-light margin-bottom-5 display-flex flex-align-center cursor-pointer'
           >
-            <Icon.ArrowBack size={3} className='margin-right-1' />
+            <Icon.ArrowBack
+              size={3}
+              className='margin-right-1'
+              aria-hidden='true' // purely decorative
+            />
             Back
           </Link>
           <h1 className='font-sans-2xl text-uppercase text-bold line-height-body-2 margin-0 margin-bottom-1'>


### PR DESCRIPTION
This PR adds the missing skip navigation button that was unintentionally left out during the header implementation in #3. This improves accessibility by allowing keyboard users to bypass repeated content.

The focus styles for the main element have been updated by replacing SCSS with utility classes. The tabIndex is now controlled dynamically via an onClick handler to keep related logic in one place, making the code more robust against accidental removal during future refactoring.

ARIA attributes—specifically aria-label and aria-hidden—have been added to Icon components to improve screen reader support. Interestingly, these issues were not flagged by Playwright’s accessibility checks, but were surfaced in the Vitest logs. It may be worth investigating why Playwright missed them.