### PR TITLE
feat: Add pubDate to Theme page, remove back link

### DIFF
--- a/app/content/themes/air-quality.mdx
+++ b/app/content/themes/air-quality.mdx
@@ -2,6 +2,7 @@
 title: "Air Quality"
 description: "The quality of the air you breathe every day has a big impact on your health. Air quality monitors on the ground and in space help us see where air pollution is improving and where there is more work to be done."
 image: "/images/themes/air-quality/air-quality-banner.png"
+pubDate: "November 27, 2023"
 ---
 
 <Section>

--- a/app/content/utils/mdx.ts
+++ b/app/content/utils/mdx.ts
@@ -22,6 +22,7 @@ type ThemeFrontmatter = {
   title: string;
   description: string;
   image: string;
+  pubDate?: string;
 };
 
 const STORY_CONTENT_PATH = path.join(

--- a/app/themes/ThemeHero.test.tsx
+++ b/app/themes/ThemeHero.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import ThemeHero from './ThemeHero';
+
+describe('Theme Hero Component', () => {
+  it('renders the component', () => {
+    render(
+      <ThemeHero
+        title='Air Quality'
+        description='Air quality is important'
+        coverSrc='https://example.com/air-quality.jpg'
+      />,
+    );
+    expect(screen.getByText('Air Quality')).toBeInTheDocument();
+    expect(screen.queryByText(/Published on/)).not.toBeInTheDocument();
+  });
+
+  it('renders the pub date', () => {
+    render(
+      <ThemeHero
+        title='Air Quality'
+        description='Air quality is important'
+        coverSrc='https://example.com/air-quality.jpg'
+        pubDate='November 27, 2023'
+      />,
+    );
+    expect(
+      screen.getByText('Published on November 27, 2023'),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/themes/ThemeHero.tsx
+++ b/app/themes/ThemeHero.tsx
@@ -1,36 +1,31 @@
 'use client';
 
 import React from 'react';
-import { Icon } from '@trussworks/react-uswds';
-import Link from 'next/link';
 
 type ThemeHeroProps = {
   title: string;
   description: string;
   coverSrc: string;
+  pubDate?: string;
 };
 
 export default function ThemeHero({
   title,
   description,
   coverSrc,
+  pubDate,
 }: ThemeHeroProps) {
   return (
     <section
       className='theme-hero'
+      data-testid='theme-hero'
       style={{
         backgroundImage: `linear-gradient(180deg, rgba(27, 27, 27, 0.1) 0%, rgba(27, 27, 27, 0.75) 100%), url(${coverSrc})`,
       }}
     >
       <div className='theme-hero__content grid-container text-white display-flex flex-align-center'>
         <div className='tablet:grid-col-8 desktop-lg:margin-left-neg-15'>
-          <Link
-            href='/'
-            className='usa-link text-primary-light margin-bottom-5 display-flex flex-align-center cursor-pointer'
-          >
-            <Icon.ArrowBack size={3} className='margin-right-1' />
-            Back
-          </Link>
+          {pubDate && <p className='margin-bottom-4'>Published on {pubDate}</p>}
           <h1 className='font-sans-2xl text-uppercase text-bold line-height-body-2 margin-0 margin-bottom-1'>
             {title}
           </h1>

--- a/app/themes/[theme]/page.tsx
+++ b/app/themes/[theme]/page.tsx
@@ -33,6 +33,7 @@ export default async function ThemePage({
           title={frontmatter.title}
           description={frontmatter.description}
           coverSrc={frontmatter.image}
+          pubDate={frontmatter.pubDate}
         />
         {content}
       </div>

--- a/test/integration/theme-page.spec.ts
+++ b/test/integration/theme-page.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Theme page', () => {
+  test('On the home page, click on the Themes dropdown takes to a theme page', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // click on the themes dropdown
+    await page.locator('button[aria-controls="themesDropDown"]').click();
+
+    // click on the themes dropdown item
+    await page.locator('a[href="/themes/air-quality"]').click();
+
+    // expect to be on the theme page
+    await expect(page).toHaveURL('/themes/air-quality');
+
+    // hero includes pub date
+    await expect(page.getByTestId('theme-hero')).toContainText(
+      'Published on November 27, 2023',
+    );
+  });
+});


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/veda-ui/issues/1639.

Changes:

- Remove back link as [requested](https://github.com/NASA-IMPACT/veda-ui/issues/1639#issuecomment-2847818663)
- Add pubDate as optional property to the ThemeHero component
- Add unit and e2e tests
- Add placeholder pubDate to air-quality.mdx for visual inspection

This is ready for review.