### PR TITLE
Add blank pages with grid layout

### DIFF
--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -12,8 +12,8 @@ export default function AboutLayout({
     // around the GridContainer to achieve that.
     <div className='desktop:bg-white'>
       <GridContainer
-        containerSize='widescreen'
-        className='desktop:bg-white desktop:text-ink desktop:padding-x-15 desktop:padding-y-10'
+        containerSize='desktop-lg'
+        className='desktop:text-ink desktop:padding-y-10'
       >
         <Grid row className='margin-bottom-4'>
           <h1 className='text-uppercase'>About</h1>

--- a/app/components/header/__snapshots__/header.test.tsx.snap
+++ b/app/components/header/__snapshots__/header.test.tsx.snap
@@ -201,13 +201,12 @@ exports[`Header Component > matches the snapshot (no unintended side-effects) 1`
         <li
           class="usa-nav__primary-item"
         >
-          <button
+          <a
             class="usa-button usa-button--outline usa-button--inverse"
-            data-testid="button"
-            type="button"
+            href="/dashboard"
           >
             Dashboard
-          </button>
+          </a>
         </li>
       </ul>
     </nav>

--- a/app/components/header/header.scss
+++ b/app/components/header/header.scss
@@ -71,6 +71,19 @@ header {
         font-weight: bold;
       }
     }
+
+    .usa-nav__primary-item {
+      .usa-nav__link, .usa-button {
+        &:hover{
+          color: utils.color('base-light') !important;
+        }
+      }
+      .usa-button {
+        &:hover {
+          box-shadow: inset 0 0 0 2px utils.color('base-light') !important;
+        }
+      }
+    }
   }
 
   @media (max-width: spacing.units('desktop')) {

--- a/app/components/header/index.tsx
+++ b/app/components/header/index.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import {
-  Button,
   Header as USWDSHeader,
   Icon,
   Menu,
@@ -80,17 +79,17 @@ export default function Header() {
         className={`${isDropdownOpen[0] ? 'bg-ink ' : ''}text-white`}
       />
     </div>,
-    <>
-      {isMobileExpanded ? (
-        <Link href='/dashboard' key='dashboard' className='usa-nav__link'>
-          <span>Dashboard</span>
-        </Link>
-      ) : (
-        <Button key='dashboard' type='button' outline inverse>
-          Dashboard
-        </Button>
-      )}
-    </>,
+    <Link
+      href='/dashboard'
+      key='dashboard'
+      className={
+        isMobileExpanded
+          ? 'usa-nav__link'
+          : 'usa-button usa-button--outline usa-button--inverse'
+      }
+    >
+      Dashboard
+    </Link>,
   ];
 
   const skipNav = (e) => {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,18 @@
+import { Grid, GridContainer } from '@trussworks/react-uswds';
+import React from 'react';
+
+const DashboardPage: React.FC = () => {
+  return (
+    <GridContainer containerSize='desktop-lg' className='desktop:padding-y-10'>
+      <Grid row className='margin-bottom-4'>
+        <h1 className='text-uppercase'>Explore</h1>
+      </Grid>
+      <Grid row>
+        {/* Add content here! */}
+        <p>Welcome to the dashboard!</p>
+      </Grid>
+    </GridContainer>
+  );
+};
+
+export default DashboardPage;

--- a/app/visit/hq/page.tsx
+++ b/app/visit/hq/page.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Grid, GridContainer } from '@trussworks/react-uswds';
+
+import { Paragraph } from 'app/components/common/Paragraph';
+
+const HqPage: React.FC = () => {
+  return (
+    <GridContainer containerSize='desktop-lg' className='desktop:padding-y-10'>
+      <Grid row className='margin-bottom-4 measure-1 desktop:measure-4'>
+        <h1 className='text-uppercase'>NASA HQ</h1>
+        <Paragraph>
+          The Earth Information Center at HQ is a physical and virtual
+          experience at NASA Headquarters, where visitors can see how our planet
+          is changing in areas that affect lives and livelihoods– from
+          temperatures in our cities to sea level rise, greenhouse gas emissions
+          to agricultural productivity.
+        </Paragraph>
+      </Grid>
+      <Grid row>{/* Add other content here! */}</Grid>
+    </GridContainer>
+  );
+};
+
+export default HqPage;

--- a/app/visit/ksc/page.tsx
+++ b/app/visit/ksc/page.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Grid, GridContainer } from '@trussworks/react-uswds';
+
+import { Paragraph } from 'app/components/common/Paragraph';
+
+const KscPage: React.FC = () => {
+  return (
+    <GridContainer containerSize='desktop-lg' className='desktop:padding-y-10'>
+      <Grid row className='margin-bottom-4 measure-1 desktop:measure-4'>
+        <h1 className='text-uppercase'>KENNEDY SPACE CENTER</h1>
+        <Paragraph>
+          The Earth Information Center exhibit at the Kennedy Space Center
+          Visitor Complex reimagines the observation gantry at Launch Complex 39
+          and includes a data hub featuring a theater show, a Hyperwall display,
+          and an interactive exhibit gallery.
+        </Paragraph>
+      </Grid>
+      <Grid row>{/* Add other content here! */}</Grid>
+    </GridContainer>
+  );
+};
+
+export default KscPage;

--- a/app/visit/nmnh/page.tsx
+++ b/app/visit/nmnh/page.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Grid, GridContainer } from '@trussworks/react-uswds';
+
+import { Paragraph } from 'app/components/common/Paragraph';
+
+const NmnhPage: React.FC = () => {
+  return (
+    <GridContainer containerSize='desktop-lg' className='desktop:padding-y-10'>
+      <Grid row className='margin-bottom-4 measure-1 desktop:measure-4'>
+        <h1 className='text-uppercase'>
+          Smithsonian National Museum of Natural History
+        </h1>
+        <Paragraph>
+          The Earth Information Center exhibit at the Smithsonian’s National
+          Museum of Natural History includes a video wall displaying Earth
+          science data visualizations and videos, an interpretive panel showing
+          Earth’s connected systems, information on our changing world, and an
+          overview of how NASA and the Smithsonian study our home planet.
+        </Paragraph>
+      </Grid>
+      <Grid row>{/* Add other content here! */}</Grid>
+    </GridContainer>
+  );
+};
+
+export default NmnhPage;

--- a/app/visit/page.tsx
+++ b/app/visit/page.tsx
@@ -1,0 +1,21 @@
+import { Grid, GridContainer } from '@trussworks/react-uswds';
+import React from 'react';
+
+const DashboardPage: React.FC = () => {
+  return (
+    <GridContainer containerSize='desktop-lg' className='desktop:padding-y-10'>
+      <Grid row className='margin-bottom-4'>
+        <h1 className='text-uppercase'>Plan your visit</h1>
+        <p>
+          The Earth Information Center currently has three physical exhibits
+          located at: NASA HQ (Washington, DC), Smithsonian Museum of Natural
+          History (Washington, DC), and Kennedy Space Center (Merritt Island,
+          Florida). All exhibits are open to the public.
+        </p>
+      </Grid>
+      <Grid row>{/* Add center cards here! */}</Grid>
+    </GridContainer>
+  );
+};
+
+export default DashboardPage;

--- a/app/visit/page.tsx
+++ b/app/visit/page.tsx
@@ -1,21 +1,23 @@
-import { Grid, GridContainer } from '@trussworks/react-uswds';
 import React from 'react';
+import { Grid, GridContainer } from '@trussworks/react-uswds';
 
-const DashboardPage: React.FC = () => {
+import { Paragraph } from 'app/components/common/Paragraph';
+
+const VisitPage: React.FC = () => {
   return (
     <GridContainer containerSize='desktop-lg' className='desktop:padding-y-10'>
-      <Grid row className='margin-bottom-4'>
+      <Grid row className='margin-bottom-4 measure-1 desktop:measure-4'>
         <h1 className='text-uppercase'>Plan your visit</h1>
-        <p>
+        <Paragraph>
           The Earth Information Center currently has three physical exhibits
           located at: NASA HQ (Washington, DC), Smithsonian Museum of Natural
           History (Washington, DC), and Kennedy Space Center (Merritt Island,
           Florida). All exhibits are open to the public.
-        </p>
+        </Paragraph>
       </Grid>
       <Grid row>{/* Add center cards here! */}</Grid>
     </GridContainer>
   );
 };
 
-export default DashboardPage;
+export default VisitPage;

--- a/test/integration/a11y.spec.ts
+++ b/test/integration/a11y.spec.ts
@@ -54,20 +54,32 @@ test.describe('Dashboard page', () => {
 });
 
 test.describe('Visit page', () => {
-  test('should not have any automatically detectable accessibility issues', async ({
-    page,
-  }, testInfo) => {
-    await page.goto('/visit');
-    await expect(page.locator('h1')).toHaveText(/Plan your visit/i);
-    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+  const visitPages = [
+    { path: '/visit', heading: /Plan your visit/i },
+    { path: '/visit/hq', heading: /NASA HQ/i },
+    { path: '/visit/ksc', heading: /KENNEDY SPACE CENTER/i },
+    {
+      path: '/visit/nmnh',
+      heading: /Smithsonian National Museum of Natural History/i,
+    },
+  ];
 
-    await testInfo.attach('accessibility-scan-results', {
-      body: JSON.stringify(accessibilityScanResults, null, 2),
-      contentType: 'application/json',
+  for (const { path, heading } of visitPages) {
+    test(`should not have any automatically detectable accessibility issues on ${path}`, async ({
+      page,
+    }, testInfo) => {
+      await page.goto(path);
+      await expect(page.locator('h1')).toHaveText(heading);
+      const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+      await testInfo.attach('accessibility-scan-results', {
+        body: JSON.stringify(accessibilityScanResults, null, 2),
+        contentType: 'application/json',
+      });
+
+      expect(accessibilityScanResults.violations).toEqual([]);
     });
-
-    expect(accessibilityScanResults.violations).toEqual([]);
-  });
+  }
 });
 
 test.describe('Not Found page', () => {

--- a/test/integration/a11y.spec.ts
+++ b/test/integration/a11y.spec.ts
@@ -36,6 +36,23 @@ test.describe('About page', () => {
   });
 });
 
+test.describe('Dashboard page', () => {
+  test('should not have any automatically detectable accessibility issues', async ({
+    page,
+  }, testInfo) => {
+    await page.goto('/dashboard');
+    await expect(page.locator('h1')).toHaveText(/Explore/i);
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    await testInfo.attach('accessibility-scan-results', {
+      body: JSON.stringify(accessibilityScanResults, null, 2),
+      contentType: 'application/json',
+    });
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});
+
 test.describe('Not Found page', () => {
   test('should not have any automatically detectable accessibility issues', async ({
     page,

--- a/test/integration/a11y.spec.ts
+++ b/test/integration/a11y.spec.ts
@@ -53,6 +53,23 @@ test.describe('Dashboard page', () => {
   });
 });
 
+test.describe('Visit page', () => {
+  test('should not have any automatically detectable accessibility issues', async ({
+    page,
+  }, testInfo) => {
+    await page.goto('/visit');
+    await expect(page.locator('h1')).toHaveText(/Plan your visit/i);
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    await testInfo.attach('accessibility-scan-results', {
+      body: JSON.stringify(accessibilityScanResults, null, 2),
+      contentType: 'application/json',
+    });
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+});
+
 test.describe('Not Found page', () => {
   test('should not have any automatically detectable accessibility issues', async ({
     page,


### PR DESCRIPTION
Close https://github.com/NASA-IMPACT/veda-ui/issues/1617

This PR adds the missing pages: `/dashboard`, `/visit`, and `/visit/[center]`. Each page is set up with its own folder and component structure.

There’s a fair bit of repetition in the layout across these pages. I considered extracting a shared layout component, but decided against it for now since the layout isn’t used everywhere, and each page has different headings and copy. The tweaks to the base Grid components are minor (only few utility classes), and I don’t expect them to change much.

I also added basic accessibility checks for all the new pages to the playwright test suite.