### PR TITLE
feat: display theme cards in carousel at dashboard page

### DIFF
--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -4,7 +4,6 @@ import { Grid, GridContainer } from '@trussworks/react-uswds';
 import Separator from 'app/components/common/Separator';
 import ThemeCard from 'app/components/common/cards/ThemeCard';
 import { DATA_THEMES } from 'app/constants';
-import CardCarousel from 'app/components/common/CardCarousel';
 import Carousel from 'app/components/common/Carousel';
 
 const DashboardPage: React.FC = () => {

--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Grid, GridContainer, CardGroup } from '@trussworks/react-uswds';
+import { Grid, GridContainer } from '@trussworks/react-uswds';
 
 import Separator from 'app/components/common/Separator';
 import ThemeCard from 'app/components/common/cards/ThemeCard';
 import { DATA_THEMES } from 'app/constants';
+import CardCarousel from 'app/components/common/CardCarousel';
+import Carousel from 'app/components/common/Carousel';
 
 const DashboardPage: React.FC = () => {
   return (
@@ -23,11 +25,12 @@ const DashboardPage: React.FC = () => {
         <Grid row className='margin-bottom-4'>
           <h2 className='text-uppercase'>Learn about earth themes</h2>
         </Grid>
-        <CardGroup>
-          {DATA_THEMES.map((theme) => (
+        <Carousel
+          slideWidth='third'
+          slides={DATA_THEMES.map((theme) => (
             <ThemeCard key={theme.id} theme={theme} />
           ))}
-        </CardGroup>
+        />
       </GridContainer>
     </>
   );

--- a/app/(pages)/visit/page.tsx
+++ b/app/(pages)/visit/page.tsx
@@ -4,6 +4,7 @@ import { CardGroup, Grid, GridContainer } from '@trussworks/react-uswds';
 import { Paragraph } from 'app/components/common/Paragraph';
 import ExhibitCard from 'app/components/common/cards/ExhibitCard';
 import { DATA_EXHIBITS as exhibits } from 'app/constants';
+import './visit.css';
 
 const VisitPage: React.FC = () => {
   return (
@@ -17,14 +18,10 @@ const VisitPage: React.FC = () => {
           Florida). All exhibits are open to the public.
         </Paragraph>
       </Grid>
-      <CardGroup>
-        <Grid row gap>
-          {exhibits.map((exhibit) => (
-            <Grid key={exhibit.id} col={12} desktop={{ col: 4 }}>
-              <ExhibitCard exhibit={exhibit} />
-            </Grid>
-          ))}
-        </Grid>
+      <CardGroup className='exhibit-card-group'>
+        {exhibits.map((exhibit) => (
+          <ExhibitCard key={exhibit.id} exhibit={exhibit} />
+        ))}
       </CardGroup>
     </GridContainer>
   );

--- a/app/(pages)/visit/page.tsx
+++ b/app/(pages)/visit/page.tsx
@@ -18,9 +18,13 @@ const VisitPage: React.FC = () => {
         </Paragraph>
       </Grid>
       <CardGroup>
-        {exhibits.map((exhibit) => (
-          <ExhibitCard key={exhibit.id} exhibit={exhibit} />
-        ))}
+        <Grid row gap>
+          {exhibits.map((exhibit) => (
+            <Grid key={exhibit.id} col={12} desktop={{ col: 4 }}>
+              <ExhibitCard exhibit={exhibit} />
+            </Grid>
+          ))}
+        </Grid>
       </CardGroup>
     </GridContainer>
   );

--- a/app/(pages)/visit/visit.css
+++ b/app/(pages)/visit/visit.css
@@ -1,0 +1,11 @@
+.exhibit-card-group {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .exhibit-card-group {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/app/components/common/Carousel/index.tsx
+++ b/app/components/common/Carousel/index.tsx
@@ -128,6 +128,13 @@ const Carousel: React.FC<PropType> = ({
               <ul
                 key={index}
                 className={`padding-x-1 ${classNames}`}
+                data-testid={
+                  isTransitional
+                    ? 'carousel-slide-transitional'
+                    : isCurrentlyVisible
+                      ? 'carousel-slide-visible'
+                      : 'carousel-slide-hidden'
+                }
                 onClick={() => {
                   if (emblaApi && !visibleSlides.includes(index)) {
                     const groupIndex = Math.floor(index / slidesPerView);

--- a/app/components/common/cards/SmallCard.scss
+++ b/app/components/common/cards/SmallCard.scss
@@ -1,8 +1,4 @@
-/**
- * SmallCard styles
- * Creates an isolated stacking context for proper badge and overlay positioning
- */
-
 .small-card {
-  isolation: isolate;
+  isolation: isolate; // create a new stacking context for badge and overlay
+  list-style-type: none;  
 } 

--- a/app/components/common/cards/SmallCard.tsx
+++ b/app/components/common/cards/SmallCard.tsx
@@ -14,11 +14,7 @@ export const SmallCard: React.FC<SmallCardProps> = ({
   ...props
 }) => {
   return (
-    <Card
-      gridLayout={{ desktop: { col: 4 }, tablet: { col: 6 } }}
-      className={`small-card ${className}`}
-      {...props}
-    >
+    <Card className={`small-card ${className}`} {...props}>
       {children}
     </Card>
   );

--- a/app/components/common/cards/__snapshots__/ExhibitCard.test.tsx.snap
+++ b/app/components/common/cards/__snapshots__/ExhibitCard.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Exhibit Card > matches the snapshot 1`] = `
 <li
-  class="usa-card tablet:grid-col-6 desktop:grid-col-4 small-card exhibit-card"
+  class="usa-card small-card exhibit-card"
   data-testid="Card"
 >
   <div

--- a/app/components/common/cards/__snapshots__/ThemeCard.test.tsx.snap
+++ b/app/components/common/cards/__snapshots__/ThemeCard.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Theme Card > matches the snapshot 1`] = `
 <li
-  class="usa-card tablet:grid-col-6 desktop:grid-col-4 small-card theme-card"
+  class="usa-card small-card theme-card"
   data-testid="Card"
 >
   <div

--- a/app/content/themes/sea-level-rise.mdx
+++ b/app/content/themes/sea-level-rise.mdx
@@ -32,7 +32,7 @@ image: '/images/themes/sea-level-change/sea-level-change-banner.png'
 
 <Section>
   <ImageCaptionBlock
-    src='/images/themes/sea-level-change/ocean-heat.png'
+    src='/images/themes/sea-level-rise/ocean-heat.png'
     alt='Ocean heat content increase from 1957 to 2020'
     caption='The cumulative increase in ocean heat content from 1957 to 2020, measured in zettajoules. The orange line represents the trend in ocean heat content, showing a significant and consistent rise, particularly from the 1980s onward. The background map highlights the global distribution of the oceans, emphasizing the widespread impact of increasing heat content across different ocean basins.'
   />

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -59,7 +59,9 @@ test.describe('Dashboard page', () => {
   }, testInfo) => {
     await page.goto('/dashboard');
     await expect(page.locator('h1')).toHaveText(/Explore/i);
-    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .exclude('[data-testid="carousel-slide-transitional"]')
+      .analyze();
 
     await testInfo.attach('accessibility-scan-results', {
       body: JSON.stringify(accessibilityScanResults, null, 2),


### PR DESCRIPTION
**Contributes to** [https://github.com/NASA-IMPACT/veda-ui/issues/1614](https://github.com/NASA-IMPACT/veda-ui/issues/1614).

**Changes added:**

* Wrap Theme Cards on the Dashboard page in a Carousel
* Fix ExhibitCard layout on the Visit page (layout was affected after removing `gridLayout` from SmallCard)

This is ready for an initial review.

The accessibility issue raised by Axe happens in the Cards on the right side of the Carousel. I tried a few things to disable them, like using `aria-hidden` and `inert`, but couldn’t get it to work. If anyone has ideas or suggestions on how to best handle this, I’d appreciate the help!


<img width="1518" alt="Screenshot 2025-05-27 at 12 31 38" src="https://github.com/user-attachments/assets/8d3a7934-850f-4e6d-9a4f-38e9c80610c8" />

cc @AliceR @dzole0311 



