### PR TITLE
feat: Add ExhibitCards on the About page

### DIFF
--- a/app/(pages)/about/ExhibitSection.tsx
+++ b/app/(pages)/about/ExhibitSection.tsx
@@ -21,7 +21,7 @@ const ExhibitSection: React.FC<ExhibitSectionProps> = ({
       {featuredExhibit && (
         <ExhibitCard
           exhibit={featuredExhibit}
-          variant='filled'
+          showDescription
           containerProps={{
             className: 'border-base-lightest bg-base-lightest',
           }}
@@ -34,7 +34,7 @@ const ExhibitSection: React.FC<ExhibitSectionProps> = ({
             <ul className='grid-col-12 tablet:grid-col-6' key={exhibit.id}>
               <ExhibitCard
                 exhibit={exhibit}
-                variant='filled'
+                showDescription
                 containerProps={{
                   className: 'border-base-lightest bg-base-lightest',
                 }}

--- a/app/(pages)/about/ExhibitSection.tsx
+++ b/app/(pages)/about/ExhibitSection.tsx
@@ -1,0 +1,50 @@
+'use client';
+import React from 'react';
+import { CardGroup } from '@trussworks/react-uswds';
+import { DATA_EXHIBITS as exhibits } from 'app/constants';
+import ExhibitCard from 'app/components/common/cards/ExhibitCard';
+
+interface ExhibitSectionProps {
+  featuredExhibitId?: string;
+  className?: string;
+}
+
+const ExhibitSection: React.FC<ExhibitSectionProps> = ({
+  featuredExhibitId = 'smithsonian-museum',
+  className = 'margin-top-1',
+}) => {
+  const featuredExhibit = exhibits.find((e) => e.id === featuredExhibitId);
+  const otherExhibits = exhibits.filter((e) => e.id !== featuredExhibitId);
+
+  return (
+    <CardGroup className={`display-flex flex-column ${className}`}>
+      {featuredExhibit && (
+        <ExhibitCard
+          exhibit={featuredExhibit}
+          variant='filled'
+          containerProps={{
+            className: 'border-base-lightest bg-base-lightest',
+          }}
+        />
+      )}
+
+      {otherExhibits.length > 0 && (
+        <div className='grid-row grid-gap margin-top-1'>
+          {otherExhibits.map((exhibit) => (
+            <div className='grid-col-12 tablet:grid-col-6' key={exhibit.id}>
+              <ExhibitCard
+                exhibit={exhibit}
+                variant='filled'
+                containerProps={{
+                  className: 'border-base-lightest bg-base-lightest',
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </CardGroup>
+  );
+};
+
+export default ExhibitSection;

--- a/app/(pages)/about/ExhibitSection.tsx
+++ b/app/(pages)/about/ExhibitSection.tsx
@@ -29,9 +29,9 @@ const ExhibitSection: React.FC<ExhibitSectionProps> = ({
       )}
 
       {otherExhibits.length > 0 && (
-        <div className='grid-row grid-gap margin-top-1'>
+        <li className='grid-row grid-gap margin-top-1'>
           {otherExhibits.map((exhibit) => (
-            <div className='grid-col-12 tablet:grid-col-6' key={exhibit.id}>
+            <ul className='grid-col-12 tablet:grid-col-6' key={exhibit.id}>
               <ExhibitCard
                 exhibit={exhibit}
                 variant='filled'
@@ -39,9 +39,9 @@ const ExhibitSection: React.FC<ExhibitSectionProps> = ({
                   className: 'border-base-lightest bg-base-lightest',
                 }}
               />
-            </div>
+            </ul>
           ))}
-        </div>
+        </li>
       )}
     </CardGroup>
   );

--- a/app/(pages)/about/page.mdx
+++ b/app/(pages)/about/page.mdx
@@ -1,9 +1,13 @@
+import ExhibitSection from './ExhibitSection';
+
 <h2 id='plan your visit'>Visit the Earth Information Center Exhibits</h2>
 
 The Earth Information Center currently has three physical exhibits located at:
 NASA HQ (Washington, DC), Smithsonian Museum of Natural History (Washington,
 DC), and Kennedy Space Center (Merritt Island, Florida). All exhibits are open
 to the public.
+
+<ExhibitSection />
 
 <h2 id='contact us'>Contact Information</h2>
 

--- a/app/components/common/cards/ExhibitCard.tsx
+++ b/app/components/common/cards/ExhibitCard.tsx
@@ -21,6 +21,12 @@ interface FormattedSectionProps {
   lines: string[];
 }
 
+interface ExhibitCardProps {
+  exhibit: Exhibit;
+  variant?: 'default' | 'filled';
+  containerProps?: { className?: string };
+}
+
 const FormattedSection: React.FC<FormattedSectionProps> = ({
   heading,
   lines,
@@ -37,10 +43,20 @@ const FormattedSection: React.FC<FormattedSectionProps> = ({
   );
 };
 
-export const ExhibitCard: React.FC<{ exhibit: Exhibit }> = ({ exhibit }) => {
+export const ExhibitCard: React.FC<ExhibitCardProps> = ({
+  exhibit,
+  variant = 'default',
+  containerProps,
+}) => {
+  const isFilled = variant === 'filled';
+
   return (
-    <SmallCard key={exhibit.id} className='exhibit-card'>
-      <CardHeader />
+    <SmallCard
+      key={exhibit.id}
+      className='exhibit-card'
+      containerProps={containerProps}
+    >
+      <CardHeader className={isFilled ? 'bg-base-lightest' : ''} />
       <CardMedia exdent className='position-relative'>
         <CardBadge
           label='Exhibit'

--- a/app/components/common/cards/ExhibitCard.tsx
+++ b/app/components/common/cards/ExhibitCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from 'react';
-import { CardMedia, CardHeader, CardBody } from '@trussworks/react-uswds';
+import { CardMedia, CardBody } from '@trussworks/react-uswds';
 import Image from 'next/image';
 import Link from 'next/link';
 import CardBadge from './CardBadge';
@@ -14,6 +14,7 @@ export interface Exhibit {
   address: string[];
   imgSrc: string;
   imgAlt: string;
+  description?: string;
 }
 
 interface FormattedSectionProps {
@@ -23,7 +24,7 @@ interface FormattedSectionProps {
 
 interface ExhibitCardProps {
   exhibit: Exhibit;
-  variant?: 'default' | 'filled';
+  showDescription?: boolean;
   containerProps?: { className?: string };
 }
 
@@ -45,18 +46,15 @@ const FormattedSection: React.FC<FormattedSectionProps> = ({
 
 export const ExhibitCard: React.FC<ExhibitCardProps> = ({
   exhibit,
-  variant = 'default',
+  showDescription,
   containerProps,
 }) => {
-  const isFilled = variant === 'filled';
-
   return (
     <SmallCard
       key={exhibit.id}
       className='exhibit-card'
       containerProps={containerProps}
     >
-      <CardHeader className={isFilled ? 'bg-base-lightest' : ''} />
       <CardMedia exdent className='position-relative'>
         <CardBadge
           label='Exhibit'
@@ -77,10 +75,17 @@ export const ExhibitCard: React.FC<ExhibitCardProps> = ({
           {exhibit.heading}
         </h2>
       </CardMedia>
-      <CardBody className='font-body-2xs height-card'>
-        <FormattedSection heading='Hours' lines={exhibit.openingHours} />
-        <FormattedSection heading='Address' lines={exhibit.address} />
+      <CardBody className='font-body-2xs height-card margin-top-2'>
+        {showDescription ? (
+          <p>{exhibit.description}</p>
+        ) : (
+          <>
+            <FormattedSection heading='Hours' lines={exhibit.openingHours} />
+            <FormattedSection heading='Address' lines={exhibit.address} />
+          </>
+        )}
       </CardBody>
+
       <Link
         className='position-absolute top-0 left-0 width-full height-full'
         href={`/visit/exhibit/${exhibit.id}`}

--- a/app/components/common/cards/__snapshots__/ExhibitCard.test.tsx.snap
+++ b/app/components/common/cards/__snapshots__/ExhibitCard.test.tsx.snap
@@ -9,10 +9,6 @@ exports[`Exhibit Card > matches the snapshot 1`] = `
     class="usa-card__container"
   >
     <div
-      class="usa-card__header"
-      data-testid="CardHeader"
-    />
-    <div
       class="usa-card__media usa-card__media--exdent position-relative"
       data-testid="CardMedia"
     >
@@ -71,7 +67,7 @@ exports[`Exhibit Card > matches the snapshot 1`] = `
       </div>
     </div>
     <div
-      class="usa-card__body font-body-2xs height-card"
+      class="usa-card__body font-body-2xs height-card margin-top-2"
       data-testid="CardBody"
     >
       <h3

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -63,6 +63,8 @@ export const DATA_EXHIBITS: Exhibit[] = [
   {
     id: 'nasa-hq',
     heading: 'NASA HQ',
+    description:
+      'The Earth Information Center at HQ is a physical and virtual experience at NASA Headquarters, where visitors can see how our planet is changing in areas that affect lives and livelihoods– from temperatures in our cities to sea level rise, greenhouse gas emissions to agricultural productivity.',
     openingHours: ['Monday - Friday', '8:30am - 5:30pm'],
     address: [
       'NASA Headquarters (East Lobby)',
@@ -74,6 +76,8 @@ export const DATA_EXHIBITS: Exhibit[] = [
   {
     id: 'smithsonian-museum',
     heading: 'Smithsonian National Museum of Natural History',
+    description:
+      'The Earth Information Center exhibit at the Smithsonian’s National Museum of Natural History includes a video wall displaying Earth science data visualizations and videos, an interpretive panel showing Earth’s connected systems, information on our changing world, and an overview of how NASA and the Smithsonian study our home planet.',
     openingHours: ['Every day (closed on Christmas)', '10am - 5:30pm'],
     address: [
       'Smithsonian National Museum of Natural History',
@@ -85,6 +89,8 @@ export const DATA_EXHIBITS: Exhibit[] = [
   {
     id: 'kennedy-space-center',
     heading: 'Kennedy Space Center',
+    description:
+      'The Earth Information Center exhibit at the Kennedy Space Center Visitor Complex reimagines the observation gantry at Launch Complex 39 and includes a data hub featuring a theater show, a Hyperwall display, and an interactive exhibit gallery.',
     openingHours: ['Every day (closed on Christmas)', '9am - 5pm'],
     address: [
       'KSC Visitor Complex (The Gantry at LC-39)',

--- a/app/types.ts
+++ b/app/types.ts
@@ -11,6 +11,7 @@ export interface Exhibit {
   address: string[];
   imgSrc: string;
   imgAlt: string;
+  description?: string;
 }
 
 export type Interactive = {


### PR DESCRIPTION
Re-used the existing ExhibitCard implementation as described in https://github.com/NASA-IMPACT/veda-ui/issues/1687

Changes:

1. Expanded ExhibitCard to accept a new variant prop to control background color and allow passing of optional containerProps to control card border or other styling
2. Added `ExhibitSection` component for the About page that handles the layout of exhibit cards

Test instructions:

1. Go to the About page
2. Verify that the ExhibitCards are visible and work as expected (clickable, expand to full width on small screens)
