### PR TITLE
fix: Bring back CentersSection for next-earth-gov

### DIFF
--- a/app/(pages)/dashboard/page.tsx
+++ b/app/(pages)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import ThemeCard from 'app/components/common/cards/ThemeCard';
 import InteractiveCard from 'app/components/common/cards/InteractiveCard';
 import { DATA_THEMES, DATA_INTERACTIVES } from 'app/constants';
 import Carousel from 'app/components/common/Carousel';
+import CentersSection from './CentersSection';
 
 const DashboardPage: React.FC = () => {
   return (
@@ -49,8 +50,9 @@ const DashboardPage: React.FC = () => {
             />
           ))}
         />
-
       </GridContainer>
+
+      <CentersSection />
     </>
   );
 };


### PR DESCRIPTION
There were some merge conflicts in https://github.com/NASA-IMPACT/next-earth-gov/pull/49 which removed the CentersSection added via https://github.com/NASA-IMPACT/next-earth-gov/pull/47

This PR brings back the section, so the Playwright tests will pass.