### PR TITLE
fix: force scroll to top on Exhibits page navigation

### DIFF
--- a/app/(pages)/visit/exhibit/kennedy-space-center/page.tsx
+++ b/app/(pages)/visit/exhibit/kennedy-space-center/page.tsx
@@ -10,12 +10,15 @@ import images from 'app/content/images.json';
 import { ArrowBackIcon } from 'app/components/common/Icons';
 import Tabs from 'app/components/common/Tabs';
 import { tabs } from './tabs';
+import ScrollToTop from 'app/components/ScrollToTop';
 
 const KennedySpaceCenterPage: React.FC = () => {
   const slidesIntro = createImageSlides(images['kennedy-space-center'].intro);
 
   return (
     <>
+      <ScrollToTop />
+
       <GridContainer
         containerSize='desktop-lg'
         className='desktop:padding-top-10'

--- a/app/(pages)/visit/exhibit/nasa-hq/page.tsx
+++ b/app/(pages)/visit/exhibit/nasa-hq/page.tsx
@@ -10,12 +10,15 @@ import images from 'app/content/images.json';
 import { ArrowBackIcon } from 'app/components/common/Icons';
 import Tabs from 'app/components/common/Tabs';
 import { tabs } from './tabs';
+import ScrollToTop from 'app/components/ScrollToTop';
 
 const NasaHqPage: React.FC = () => {
   const slidesIntro = createImageSlides(images['nasa-hq'].intro);
 
   return (
     <>
+      <ScrollToTop />
+
       <GridContainer
         containerSize='desktop-lg'
         className='desktop:padding-top-10'

--- a/app/(pages)/visit/exhibit/smithsonian-museum/page.tsx
+++ b/app/(pages)/visit/exhibit/smithsonian-museum/page.tsx
@@ -10,6 +10,7 @@ import images from 'app/content/images.json';
 import { ArrowBackIcon } from 'app/components/common/Icons';
 import Tabs from 'app/components/common/Tabs';
 import { tabs } from './tabs';
+import ScrollToTop from 'app/components/ScrollToTop';
 
 const SmithsonianMuseumPage: React.FC = () => {
   const slidesIntro = createImageSlides(
@@ -18,6 +19,8 @@ const SmithsonianMuseumPage: React.FC = () => {
 
   return (
     <>
+      <ScrollToTop />
+
       <GridContainer
         containerSize='desktop-lg'
         className='desktop:padding-top-10'

--- a/app/components/ScrollToTop.tsx
+++ b/app/components/ScrollToTop.tsx
@@ -11,7 +11,7 @@ import { usePathname } from 'next/navigation';
  * - removing sticky elements (e.g. sticky header)
  * - explicitly setting `scroll={true}` to `<Link>` components
  *
- * This double `requestAnimationFrame` waits until the page has fully rendered
+ * This `requestAnimationFrame` waits until the page has fully rendered
  * before forcing scroll to top. It’s a workaround, but the only reliable one for now.
  *
  * See: https://github.com/vercel/next.js/discussions/69993, https://github.com/vercel/next.js/discussions/45715
@@ -21,9 +21,7 @@ export default function ScrollToTop() {
 
   useEffect(() => {
     requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        window.scrollTo({ top: 0, behavior: 'auto' });
-      });
+      window.scrollTo({ top: 0, behavior: 'auto' });
     });
   }, [pathname]);
 

--- a/app/components/ScrollToTop.tsx
+++ b/app/components/ScrollToTop.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+/**
+ * This fixes a very strange scroll bug in Next.js
+ *
+ * There are a few reports that navigating to a new page doesn't scroll to the top,
+ * even after trying things like:
+ * - removing `overflow: hidden` or `height: 100%` from html/body or other elements
+ * - removing sticky elements (e.g. sticky header)
+ * - explicitly setting `scroll={true}` to `<Link>` components
+ *
+ * This double `requestAnimationFrame` waits until the page has fully rendered
+ * before forcing scroll to top. It’s a workaround, but the only reliable one for now.
+ *
+ * See: https://github.com/vercel/next.js/discussions/69993, https://github.com/vercel/next.js/discussions/45715
+ */
+export default function ScrollToTop() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.scrollTo({ top: 0, behavior: 'auto' });
+      });
+    });
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
closes: https://github.com/NASA-IMPACT/veda-ui/issues/1731

There's a very weird scroll position bug when navigating between certain pages where Next.js doesn’t always scroll to the top when changing routes. I tried a few things mentioned in threads like this one [here](https://github.com/vercel/next.js/discussions/69993), but this is the only approach that seems to work for me (please do suggest alternatives if you've fixed a similar issue before, or if you see concerns with this workaround).

Changes:

- Add a <ScrollToTop /> component that waits for layout/render to finish, then scrolls the page to top.

Test steps:

1. Open the https://deploy-preview-66--next-earth-gov.netlify.app/visit/
2. Click on some of the cards
3. The new page should now load scrolled to top, every time
