### PR TITLE
feat: Add center cards to theme pages

### DIFF
--- a/app/(pages)/dashboard/CentersSection.tsx
+++ b/app/(pages)/dashboard/CentersSection.tsx
@@ -10,7 +10,7 @@ const CentersSection: React.FC = () => {
     <>
       <Grid row className='margin-y-2'>
         <Grid col={12}>
-          <CenterCard center={firstCenter} isFirst={true} />
+          <CenterCard center={firstCenter} isWide={true} />
         </Grid>
       </Grid>
 
@@ -23,7 +23,7 @@ const CentersSection: React.FC = () => {
             desktop={{ col: 4 }}
             className='margin-y-2'
           >
-            <CenterCard center={center} isFirst={false} />
+            <CenterCard center={center} isWide={false} />
           </Grid>
         ))}
       </Grid>

--- a/app/components/common/cards/CenterCard.scss
+++ b/app/components/common/cards/CenterCard.scss
@@ -12,6 +12,16 @@ $image-height-wide: 200px;
   gap: spacing.units(2);
   min-height: 9rem; 
   
+  &.is-not-wide {
+    min-height: 24rem;
+    align-items: stretch;
+    
+    &__body {
+      justify-content: space-between;
+      height: 100%;
+    }
+  }
+  
   &__image {
     height: $image-height-wide; 
     width: $image-width-wide;

--- a/app/components/common/cards/CenterCard.scss
+++ b/app/components/common/cards/CenterCard.scss
@@ -7,7 +7,7 @@ $image-height-wide: 200px;
   isolation: isolate;
   display: flex;
   flex-direction: row;
-  align-items: flex-start;
+  align-items: center;
   gap: spacing.units(2);
   min-height: 9rem; 
   
@@ -23,7 +23,6 @@ $image-height-wide: 200px;
   }
 
   &__body {
-    height: 100%;
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/app/components/common/cards/CenterCard.scss
+++ b/app/components/common/cards/CenterCard.scss
@@ -1,7 +1,7 @@
 @use 'uswds-core/src/styles/functions/units' as spacing;
 
-$image-width-default: 110px;
-$image-width-first: 330px;
+$image-width-wide: 330px;
+$image-height-wide: 200px;
 
 .center-card {
   isolation: isolate;
@@ -10,13 +10,12 @@ $image-width-first: 330px;
   align-items: flex-start;
   gap: spacing.units(2);
   min-height: 9rem; 
-  height: 23rem; 
   
   &__image {
-    height: 100%;
-    
+    height: $image-height-wide; 
+    width: $image-width-wide;
+
     img {
-      width: $image-width-default;
       height: 100%;
       object-fit: cover;
       border-radius: 0.25rem;
@@ -29,11 +28,6 @@ $image-width-first: 330px;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-  }
-
-  &.is-first {
-    min-height: 12rem; 
-    padding: 20px;
   }
 
   // Mobile layout

--- a/app/components/common/cards/CenterCard.scss
+++ b/app/components/common/cards/CenterCard.scss
@@ -5,6 +5,7 @@ $image-height-wide: 200px;
 
 .center-card {
   isolation: isolate;
+  position: relative;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/app/components/common/cards/CenterCard.test.tsx
+++ b/app/components/common/cards/CenterCard.test.tsx
@@ -20,15 +20,15 @@ describe('Center Card', () => {
     expect(screen.getByText(testCenter.description)).toBeInTheDocument();
   });
 
-  it('should render the center card with image when isFirst is true', () => {
-    render(<CenterCard center={testCenter} isFirst={true} />);
+  it('should render the center card with image when isWide is true', () => {
+    render(<CenterCard center={testCenter} isWide={true} />);
     const imageElement = screen.getByAltText(testCenter.imageAlt);
     expect(imageElement).toBeInTheDocument();
     expect(imageElement).toHaveAttribute('src');
   });
 
-  it('should not render the center card image when isFirst is false', () => {
-    render(<CenterCard center={testCenter} isFirst={false} />);
+  it('should not render the center card image when isWide is false', () => {
+    render(<CenterCard center={testCenter} isWide={false} />);
     expect(screen.queryByAltText(testCenter.imageAlt)).not.toBeInTheDocument();
   });
 

--- a/app/components/common/cards/CenterCard.tsx
+++ b/app/components/common/cards/CenterCard.tsx
@@ -16,7 +16,7 @@ interface CenterCardProps {
 export const CenterCard: React.FC<CenterCardProps> = ({ center, isWide }) => {
   return (
     <div
-      className={`center-card bg-ink border-1px border-base-darkest radius-md padding-y-5 padding-x-3`}
+      className={`center-card bg-ink border-1px border-base-darkest radius-md padding-y-5 padding-x-3 ${isWide ? 'is-wide' : 'is-not-wide'}`}
     >
       {isWide && (
         <div className='center-card__image'>

--- a/app/components/common/cards/CenterCard.tsx
+++ b/app/components/common/cards/CenterCard.tsx
@@ -5,6 +5,8 @@ import './CenterCard.scss';
 import CardBadge from './CardBadge';
 import Link from 'next/link';
 import { LaunchIcon } from '../Icons';
+import { DATA_CENTERS } from 'app/constants';
+import { Grid } from '@trussworks/react-uswds';
 
 interface CenterCardProps {
   center: Center;
@@ -48,5 +50,21 @@ export const CenterCard: React.FC<CenterCardProps> = ({ center, isFirst }) => {
         aria-label={`Visit ${center.title} center.`}
       />
     </div>
+  );
+};
+
+export const CenterCardBlock: React.FC<{ centerIds: string }> = ({
+  centerIds,
+}) => {
+  const centers = DATA_CENTERS.filter((center) =>
+    centerIds.includes(center.id),
+  );
+
+  return (
+    <Grid col={12}>
+      {centers.map((center) => (
+        <CenterCard key={center.id} center={center} isFirst />
+      ))}
+    </Grid>
   );
 };

--- a/app/components/common/cards/CenterCard.tsx
+++ b/app/components/common/cards/CenterCard.tsx
@@ -63,7 +63,9 @@ export const CenterCardBlock: React.FC<{ centerIds: string }> = ({
   return (
     <Grid col={12}>
       {centers.map((center) => (
-        <CenterCard key={center.id} center={center} isWide />
+        <Grid key={center.id} row className='margin-y-2'>
+          <CenterCard key={center.id} center={center} isWide />
+        </Grid>
       ))}
     </Grid>
   );

--- a/app/components/common/cards/CenterCard.tsx
+++ b/app/components/common/cards/CenterCard.tsx
@@ -10,15 +10,15 @@ import { Grid } from '@trussworks/react-uswds';
 
 interface CenterCardProps {
   center: Center;
-  isFirst?: boolean;
+  isWide?: boolean;
 }
 
-export const CenterCard: React.FC<CenterCardProps> = ({ center, isFirst }) => {
+export const CenterCard: React.FC<CenterCardProps> = ({ center, isWide }) => {
   return (
     <div
-      className={`center-card bg-ink border-1px border-base-darkest radius-md padding-y-5 padding-x-3 ${isFirst ? 'is-first' : 'is-secondary'}`}
+      className={`center-card bg-ink border-1px border-base-darkest radius-md padding-y-5 padding-x-3 ${isWide ? 'is-first' : 'is-secondary'}`}
     >
-      {isFirst && (
+      {isWide && (
         <div className='center-card__image'>
           <Image
             width={400}
@@ -63,7 +63,7 @@ export const CenterCardBlock: React.FC<{ centerIds: string }> = ({
   return (
     <Grid col={12}>
       {centers.map((center) => (
-        <CenterCard key={center.id} center={center} isFirst />
+        <CenterCard key={center.id} center={center} isWide />
       ))}
     </Grid>
   );

--- a/app/components/common/cards/CenterCard.tsx
+++ b/app/components/common/cards/CenterCard.tsx
@@ -16,7 +16,7 @@ interface CenterCardProps {
 export const CenterCard: React.FC<CenterCardProps> = ({ center, isWide }) => {
   return (
     <div
-      className={`center-card bg-ink border-1px border-base-darkest radius-md padding-y-5 padding-x-3 ${isWide ? 'is-first' : 'is-secondary'}`}
+      className={`center-card bg-ink border-1px border-base-darkest radius-md padding-y-5 padding-x-3`}
     >
       {isWide && (
         <div className='center-card__image'>

--- a/app/content/themes/greenhouse-gases.mdx
+++ b/app/content/themes/greenhouse-gases.mdx
@@ -17,6 +17,8 @@ centerIds:
   <CenterCardBlock centerIds={centerIds} />
 </Section>
 
+<Separator />
+
 <Section>
   <Title>INFO</Title>
 

--- a/app/content/themes/greenhouse-gases.mdx
+++ b/app/content/themes/greenhouse-gases.mdx
@@ -8,7 +8,14 @@ resources:
     linkURL: "https://carbon.nasa.gov/cms/"
     imgSrc: "/images/themes/greenhouse-gases/intro-to-ghg.png"
     imgAlt: "Introduction to greenhouse gases"
+centerIds:
+  - greenhouse-gas-center
 ---
+
+<Section>
+  <Title>Visit the US Greenhouse Gas Center</Title>
+  <CenterCardBlock centerIds={centerIds} />
+</Section>
 
 <Section>
   <Title>INFO</Title>

--- a/app/content/themes/sea-level-change.mdx
+++ b/app/content/themes/sea-level-change.mdx
@@ -18,6 +18,9 @@ centerIds:
   <CenterCardBlock centerIds={centerIds} />
 </Section>
 
+
+<Separator />
+
 <Section>
   <Title>INFO</Title>
 

--- a/app/content/themes/sea-level-change.mdx
+++ b/app/content/themes/sea-level-change.mdx
@@ -8,7 +8,15 @@ resources:
     linkURL: "https://sealevel.nasa.gov/"
     imgSrc: "/images/themes/sea-level-rise/intro-to-sea-level-change.png"
     imgAlt: "Introduction to sea level change"
+centerIds:
+  - national-sea-level-rise-center
+  - global-sea-level-change-portal
 ---
+
+<Section>
+  <Title>Visit the Sea Level Change Portals</Title>
+  <CenterCardBlock centerIds={centerIds} />
+</Section>
 
 <Section>
   <Title>INFO</Title>

--- a/app/utils/mdx.ts
+++ b/app/utils/mdx.ts
@@ -5,6 +5,7 @@ import markdownit from 'markdown-it';
 
 import { compileMDX } from 'next-mdx-remote/rsc';
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { Paragraph } from 'app/components/common/Paragraph';
 import { Section } from 'app/components/common/Section';
 import { VideoCaptionBlock } from 'app/components/common/VideoCaptionBlock';
@@ -13,7 +14,7 @@ import { CenterCardBlock } from '../components/common/cards/CenterCard';
 import { Title } from 'app/components/common/Title';
 import { ExternalResources } from 'app/components/common/cards/ExternalResource';
 import Carousel from 'app/components/common/Carousel';
-import dynamic from 'next/dynamic';
+import Separator from 'app/components/common/Separator';
 
 const ClientOnly = dynamic(() => import('app/components/common/ClientOnly'), {
   ssr: false,
@@ -151,6 +152,7 @@ export async function getThemeContent(slug: string) {
       VideoCaptionBlock,
       Section,
       Paragraph,
+      Separator,
       Title,
       Carousel,
       ExternalResources,

--- a/app/utils/mdx.ts
+++ b/app/utils/mdx.ts
@@ -9,6 +9,7 @@ import { Paragraph } from 'app/components/common/Paragraph';
 import { Section } from 'app/components/common/Section';
 import { VideoCaptionBlock } from 'app/components/common/VideoCaptionBlock';
 import { ImageCaptionBlock } from 'app/components/common/ImageCaptionBlock';
+import { CenterCardBlock } from '../components/common/cards/CenterCard';
 import { Title } from 'app/components/common/Title';
 import { ExternalResources } from 'app/components/common/cards/ExternalResource';
 import Carousel from 'app/components/common/Carousel';
@@ -30,6 +31,7 @@ type ThemeFrontmatter = {
     imgSrc: string;
     imgAlt: string;
   }[];
+  centerIds?: string[];
 };
 
 const THEME_CONTENT_PATH = path.join(process.cwd(), 'app', 'content', 'themes');
@@ -152,6 +154,7 @@ export async function getThemeContent(slug: string) {
       Title,
       Carousel,
       ExternalResources,
+      CenterCardBlock,
     },
     options: {
       parseFrontmatter: false,
@@ -161,6 +164,7 @@ export async function getThemeContent(slug: string) {
         description: frontmatter.description,
         image: frontmatter.image,
         pubDate: frontmatter.pubDate,
+        centerIds: frontmatter.centerIds || [],
       },
     },
   });


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/veda-ui/issues/1733.

Changes:

- Introduces `<CenterCardBlock>` component, that can be used in mdx pages (it accepts center ids to keep single source of truth in `app/constants/DATA_CENTERS`
- Style fixes to make card image and content to appear consistent in different pages and screen sizes
- Updated frontmatter and add center cards block to sea leven change and greenhouse gases theme page

This is ready for review.