### PR TITLE
fix: Carousel and footer keyboard navigation

### DIFF
--- a/app/components/common/Carousel/CarouselArrowButtons.tsx
+++ b/app/components/common/Carousel/CarouselArrowButtons.tsx
@@ -4,8 +4,17 @@ import React, { ComponentPropsWithRef } from 'react';
 
 type ButtonProps = ComponentPropsWithRef<'button'>;
 
-export const PrevButton: React.FC<ButtonProps> = ({ children, ...props }) => (
-  <button type='button' aria-label='Prev slide' {...props}>
+export const PrevButton: React.FC<ButtonProps> = ({
+  children,
+  className,
+  ...props
+}) => (
+  <button
+    type='button'
+    aria-label='Previous slide'
+    {...props}
+    className={`${className} ${props.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+  >
     <svg
       width='18'
       height='18'
@@ -24,8 +33,23 @@ export const PrevButton: React.FC<ButtonProps> = ({ children, ...props }) => (
   </button>
 );
 
-export const NextButton: React.FC<ButtonProps> = ({ children, ...props }) => (
-  <button type='button' aria-label='Next slide' {...props}>
+export const NextButton: React.FC<ButtonProps> = ({
+  children,
+  className,
+  ...props
+}) => (
+  <button
+    type='button'
+    aria-label='Next slide'
+    {...props}
+    className={`${className} ${props.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+    style={{
+      ...(props.disabled && {
+        opacity: 0.5,
+        cursor: 'not-allowed',
+      }),
+    }}
+  >
     <svg
       width='16'
       height='16'

--- a/app/components/common/Carousel/carousel.scss
+++ b/app/components/common/Carousel/carousel.scss
@@ -1,3 +1,4 @@
+@use 'uswds-core' as *;
 @use 'uswds-core/src/styles/functions/units' as spacing;
 
 .carousel__viewport {
@@ -30,4 +31,11 @@
 
 .slide--full {
   flex: 1 0 100%;
+}
+
+// Focus styles for interactive elements inside carousel slides
+.carousel__viewport *:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 0.25rem color(primary) !important;
+  border-radius: 0 !important;
 }

--- a/app/components/common/Carousel/carousel.scss
+++ b/app/components/common/Carousel/carousel.scss
@@ -39,3 +39,21 @@
   box-shadow: inset 0 0 0 0.25rem color(primary) !important;
   border-radius: 0 !important;
 }
+
+// Ensure carousel navigation buttons remain focusable when disabled
+.carousel__controls button {
+  &:focus-visible {
+    outline: 2px solid color(primary);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    // Keep disabled buttons focusable for accessibility
+    pointer-events: none;
+    
+    &:focus-visible {
+      outline: 2px solid color('gray-50');
+      outline-offset: 2px;
+    }
+  }
+}

--- a/app/components/common/Carousel/index.tsx
+++ b/app/components/common/Carousel/index.tsx
@@ -157,6 +157,8 @@ const Carousel: React.FC<PropType> = ({
             className='usa-button--unstyled margin-right-2'
             onClick={onPrevButtonClick}
             disabled={prevBtnDisabled}
+            aria-disabled={prevBtnDisabled}
+            tabIndex={0}
           />
 
           <div className='carousel__counter'>
@@ -167,6 +169,8 @@ const Carousel: React.FC<PropType> = ({
             className='usa-button--unstyled margin-left-2'
             onClick={onNextButtonClick}
             disabled={nextBtnDisabled}
+            aria-disabled={nextBtnDisabled}
+            tabIndex={0}
           />
         </div>
       )}

--- a/app/components/footer/__snapshots__/footer.test.tsx.snap
+++ b/app/components/footer/__snapshots__/footer.test.tsx.snap
@@ -162,6 +162,24 @@ exports[`Footer Component > matches the snapshot (no unintended side-effects) 1`
         data-testid="grid"
       >
         <div
+          class="desktop:display-flex desktop:order-first"
+        >
+          <p
+            class="margin-top-0 measure-1 desktop:measure-4"
+          >
+            Looking for U.S. government information and services?
+             
+            <a
+              class="usa-link"
+              href="https://www.usa.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Visit USA.gov
+            </a>
+          </p>
+        </div>
+        <div
           class="desktop:display-flex desktop:flex-row desktop:order-last"
         >
           <div
@@ -193,24 +211,6 @@ exports[`Footer Component > matches the snapshot (no unintended side-effects) 1`
               </a>
             </p>
           </div>
-        </div>
-        <div
-          class="desktop:display-flex desktop:order-first"
-        >
-          <p
-            class="margin-top-0 measure-1 desktop:measure-4"
-          >
-            Looking for U.S. government information and services?
-             
-            <a
-              class="usa-link"
-              href="https://www.usa.gov"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              Visit USA.gov
-            </a>
-          </p>
         </div>
       </div>
     </div>

--- a/app/components/footer/tertiary-section.tsx
+++ b/app/components/footer/tertiary-section.tsx
@@ -7,6 +7,19 @@ const TertiarySection = () => {
       row
       className='border-top-1px border-base-darkest padding-top-2 desktop:display-flex flex-column desktop:flex-row text-base-light font-body-2xs'
     >
+      <div className='desktop:display-flex desktop:order-first'>
+        <p className='margin-top-0 measure-1 desktop:measure-4'>
+          Looking for U.S. government information and services?{' '}
+          <Link
+            href='https://www.usa.gov'
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            Visit USA.gov
+          </Link>
+        </p>
+      </div>
+
       <div className='desktop:display-flex desktop:flex-row desktop:order-last'>
         <div className='padding-right-4'>
           <p className='margin-top-0 measure-1 desktop:measure-4'>
@@ -22,19 +35,6 @@ const TertiarySection = () => {
             <Link href='mailto:eleanor.stokes@nasa.gov'>Eleanor Stokes</Link>
           </p>
         </div>
-      </div>
-
-      <div className='desktop:display-flex desktop:order-first'>
-        <p className='margin-top-0 measure-1 desktop:measure-4'>
-          Looking for U.S. government information and services?{' '}
-          <Link
-            href='https://www.usa.gov'
-            target='_blank'
-            rel='noopener noreferrer'
-          >
-            Visit USA.gov
-          </Link>
-        </p>
       </div>
     </Grid>
   );


### PR DESCRIPTION
Contributes to: https://github.com/NASA-IMPACT/veda-ui/issues/1706

This is focused on fixing the keyboard navigation.

Chages added:

- Display outline on carousel slides on keyboard navigation
- Display outline on carousel buttons on keyboard navigation
- Apply disabled styles to carousel buttons
- Fix keyboard navigation order of the footer

How to test: visit the dashboard page, hit tab multiple tabs to confirm all actionable elements can be focused.

This is ready for review.

