### PR TITLE
fix: add scroll observer space

### DIFF
--- a/app/(pages)/about/layout.scss
+++ b/app/(pages)/about/layout.scss
@@ -1,0 +1,8 @@
+@use 'uswds-core' as *;
+
+// Spacer element to ensure sufficient height for scroll observer
+.scroll-observer-spacer {
+  @include at-media('desktop') {
+    height: 33vh;
+  }
+}

--- a/app/(pages)/about/layout.tsx
+++ b/app/(pages)/about/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import SideNav from './side-nav';
 import { Grid, GridContainer } from '@trussworks/react-uswds';
+import './layout.scss';
 
 export default function AboutLayout({
   children,
@@ -29,6 +30,7 @@ export default function AboutLayout({
 
           <Grid col={'fill'} className='mdx margin-top-neg-2'>
             {children}
+            <div className='scroll-observer-spacer' />
           </Grid>
         </Grid>
       </GridContainer>


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/veda-ui/issues/1634.

This ensures that the last section of the about page has sufficient height to be captured by the scroll observer. It adds a spacer of about a third of the viewport height when on desktop, allowing the side navigation to capture and highlight the last section.